### PR TITLE
Add support for API ShortURL Analytics

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,15 @@ Creates a custom short URL with a specific keyword.
 - `keyword` (required): The custom keyword for the short URL (e.g., "web" for bysha.pe/web)
 - `title` (optional): Title for the URL
 
+### 6. url_analytics
+
+Gets detailed click analytics for a short URL within a date range.
+
+**Parameters:**
+- `shorturl` (required): The short URL or keyword to get analytics for
+- `date` (required): Start date for analytics in YYYY-MM-DD format
+- `date_end` (optional): End date for analytics in YYYY-MM-DD format (defaults to start date if not provided)
+
 ## Usage Examples
 
 Once configured, Claude will be able to use the YOURLS tools with prompts like:
@@ -122,6 +131,9 @@ Once configured, Claude will be able to use the YOURLS tools with prompts like:
 - "Expand this short URL: https://yourdomain.com/abc"
 - "How many clicks does my short URL https://yourdomain.com/abc have?"
 - "Show me the statistics for my YOURLS instance"
+- "Give me detailed analytics for shorturl 'abc' for January 2025"
+- "Show me the click statistics for bysha.pe/abc from 2025-01-01 to 2025-01-31"
+- "What was the daily traffic for my shortURL 'web' last month?"
 
 ## Development
 

--- a/USAGE.md
+++ b/USAGE.md
@@ -101,6 +101,26 @@ https://bysha.pe/web
 This now redirects to: https://shapescale.com
 ```
 
+### Getting Detailed Analytics for a Short URL
+
+```
+You: Can you show me the daily click statistics for bysha.pe/docs from January 1-7, 2025?
+
+Claude: Here are the detailed click statistics for bysha.pe/docs from January 1-7, 2025:
+
+Total clicks (lifetime): 87
+Clicks in date range: 23
+
+Daily breakdown:
+- January 1, 2025: 5 clicks
+- January 2, 2025: 8 clicks
+- January 3, 2025: 4 clicks
+- January 4, 2025: 2 clicks
+- January 5, 2025: 0 clicks
+- January 6, 2025: 3 clicks
+- January 7, 2025: 1 click
+```
+
 ## Practical Use Cases
 
 YOURLS-MCP is particularly useful for:

--- a/src/api.js
+++ b/src/api.js
@@ -208,4 +208,38 @@ export default class YourlsClient {
   async dbStats() {
     return this.request('db-stats', {});
   }
+  
+  /**
+   * Get detailed analytics for a short URL within a date range
+   * 
+   * @param {string} shorturl - Short URL or keyword
+   * @param {string} date - Start date in YYYY-MM-DD format
+   * @param {string} [dateEnd] - End date in YYYY-MM-DD format (defaults to start date if not provided)
+   * @returns {Promise<object>} API response with click statistics
+   */
+  async shortUrlAnalytics(shorturl, date, dateEnd = null) {
+    const params = { 
+      shorturl, 
+      date 
+    };
+    
+    if (dateEnd) {
+      params.date_end = dateEnd;
+    }
+    
+    try {
+      return this.request('shorturl_analytics', params);
+    } catch (error) {
+      // If the plugin isn't installed, we'll get an error about unknown action
+      if (error.response && 
+          error.response.data && 
+          (error.response.data.message === 'Unknown or missing action' ||
+           error.response.data.message?.includes('Unknown action'))) {
+        throw new Error('The shorturl_analytics action is not available. Please install the API ShortURL Analytics plugin.');
+      }
+      
+      // Otherwise, re-throw the original error
+      throw error;
+    }
+  }
 }

--- a/src/tools/index.js
+++ b/src/tools/index.js
@@ -5,6 +5,7 @@ import createShortenUrlTool from './shortenUrl.js';
 import createExpandUrlTool from './expandUrl.js';
 import createUrlStatsTool from './urlStats.js';
 import createDbStatsTool from './dbStats.js';
+import createShortUrlAnalyticsTool from './shortUrlAnalytics.js';
 
 /**
  * Register all tools with the MCP server
@@ -17,9 +18,11 @@ export function registerTools(server, yourlsClient) {
   const expandUrlTool = createExpandUrlTool(yourlsClient);
   const urlStatsTool = createUrlStatsTool(yourlsClient);
   const dbStatsTool = createDbStatsTool(yourlsClient);
+  const shortUrlAnalyticsTool = createShortUrlAnalyticsTool(yourlsClient);
   
   server.addTool(shortenUrlTool);
   server.addTool(expandUrlTool);
   server.addTool(urlStatsTool);
   server.addTool(dbStatsTool);
+  server.addTool(shortUrlAnalyticsTool);
 }

--- a/src/tools/shortUrlAnalytics.js
+++ b/src/tools/shortUrlAnalytics.js
@@ -1,0 +1,79 @@
+/**
+ * YOURLS-MCP Tool: Get detailed analytics for a short URL
+ */
+import { z } from 'zod';
+
+/**
+ * Creates the short URL analytics tool
+ * 
+ * @param {object} yourlsClient - YOURLS API client instance
+ * @returns {object} MCP tool definition
+ */
+export default function createShortUrlAnalyticsTool(yourlsClient) {
+  return {
+    name: 'url_analytics',
+    description: 'Get detailed click analytics for a shortened URL within a date range',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        shorturl: {
+          type: 'string',
+          description: 'The short URL or keyword to get analytics for'
+        },
+        date: {
+          type: 'string',
+          description: 'Start date for analytics (YYYY-MM-DD format)'
+        },
+        date_end: {
+          type: 'string',
+          description: 'Optional end date for analytics (YYYY-MM-DD format). Defaults to start date if not provided.'
+        }
+      },
+      required: ['shorturl', 'date']
+    },
+    execute: async ({ shorturl, date, date_end }) => {
+      try {
+        const result = await yourlsClient.shortUrlAnalytics(shorturl, date, date_end);
+        
+        if (result.stats) {
+          return {
+            content: [
+              {
+                type: 'text',
+                text: JSON.stringify({
+                  status: 'success',
+                  shorturl: shorturl,
+                  total_clicks: result.stats.total_clicks || 0,
+                  range_clicks: result.stats.range_clicks || 0,
+                  daily_clicks: result.stats.daily_clicks || {},
+                  date_range: {
+                    start: date,
+                    end: date_end || date
+                  }
+                })
+              }
+            ]
+          };
+        } else {
+          throw new Error(result.message || 'Unknown error');
+        }
+      } catch (error) {
+        return {
+          content: [
+            {
+              type: 'text',
+              text: JSON.stringify({
+                status: 'error',
+                message: error.message,
+                shorturl: shorturl,
+                date: date,
+                date_end: date_end || date
+              })
+            }
+          ],
+          isError: true
+        };
+      }
+    }
+  };
+}


### PR DESCRIPTION
## Overview
This PR adds support for the API ShortURL Analytics plugin, allowing Claude to provide detailed click statistics for short URLs within specific date ranges.

## Features Added
- Added  method to the YOURLS API client
- Created new  tool for the MCP server
- Implemented graceful error handling for when the plugin is not installed
- Added plugin to YOURLS installation in the plugins directory

## Usage
Users can now ask Claude for detailed analytics with queries like:
- "Show me the click statistics for bysha.pe/abc from January 1-7, 2025"
- "What was the daily traffic for my shortURL 'web' last month?"
- "Give me detailed analytics for shorturl 'abc' for January 2025"

## Implementation Details
- Analytics can be requested for a single day or a date range
- Results include lifetime clicks, clicks within the specified range, and a daily breakdown
- Tool follows the same error handling pattern as other tools for consistency
- Comprehensive documentation with usage examples

## Testing
Tested with YOURLS instance with the API ShortURL Analytics plugin installed.

## Documentation
- Updated README.md with new tool documentation
- Added examples to USAGE.md with sample dialog
- Added usage examples to the README

## Required Plugin
This feature requires the [API ShortURL Analytics plugin](https://github.com/stefanofranco/yourls-api-shorturl-analytics) to be installed and activated in YOURLS.