### PR TITLE
Add support for YOURLS API plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,9 @@ The following environment variables can be set in the Claude Desktop config:
 
 YOURLS-MCP provides the following tools to Claude:
 
-### 1. shorten_url
+### Core Tools
+
+#### 1. shorten_url
 
 Shortens a long URL using your YOURLS instance.
 
@@ -82,27 +84,27 @@ Shortens a long URL using your YOURLS instance.
 - `keyword` (optional): Custom keyword for the short URL
 - `title` (optional): Title for the URL
 
-### 2. expand_url
+#### 2. expand_url
 
 Expands a short URL to get the original long URL.
 
 **Parameters:**
 - `shorturl` (required): The short URL or keyword to expand
 
-### 3. url_stats
+#### 3. url_stats
 
 Gets statistics for a shortened URL.
 
 **Parameters:**
 - `shorturl` (required): The short URL or keyword to get stats for
 
-### 4. db_stats
+#### 4. db_stats
 
 Gets global statistics for your YOURLS instance.
 
 **Parameters:** None
 
-### 5. create_custom_url
+#### 5. create_custom_url
 
 Creates a custom short URL with a specific keyword.
 
@@ -111,18 +113,82 @@ Creates a custom short URL with a specific keyword.
 - `keyword` (required): The custom keyword for the short URL (e.g., "web" for bysha.pe/web)
 - `title` (optional): Title for the URL
 
-### 6. url_analytics
+### Plugin-based Tools
+
+#### 6. url_analytics
 
 Gets detailed click analytics for a short URL within a date range.
+*Requires the API ShortURL Analytics plugin to be installed.*
 
 **Parameters:**
 - `shorturl` (required): The short URL or keyword to get analytics for
 - `date` (required): Start date for analytics in YYYY-MM-DD format
 - `date_end` (optional): End date for analytics in YYYY-MM-DD format (defaults to start date if not provided)
 
+#### 7. contract_url
+
+Check if a URL has already been shortened without creating a new short URL.
+*Requires the API Contract plugin to be installed.*
+
+**Parameters:**
+- `url` (required): The URL to check if it has been shortened
+
+#### 8. update_url
+
+Update an existing short URL to point to a different destination URL.
+*Requires the API Edit URL plugin to be installed.*
+
+**Parameters:**
+- `shorturl` (required): The short URL or keyword to update
+- `url` (required): The new destination URL
+- `title` (optional): Optional new title ("keep" to keep existing, "auto" to fetch from URL)
+
+#### 9. change_keyword
+
+Change the keyword of an existing short URL.
+*Requires the API Edit URL plugin to be installed.*
+
+**Parameters:**
+- `oldshorturl` (required): The existing short URL or keyword
+- `newshorturl` (required): The new keyword to use
+- `url` (optional): Optional URL (if not provided, will use the URL from oldshorturl)
+- `title` (optional): Optional new title ("keep" to keep existing, "auto" to fetch from URL)
+
+#### 10. get_url_keyword
+
+Get the keyword(s) for a long URL.
+*Requires the API Edit URL plugin to be installed.*
+
+**Parameters:**
+- `url` (required): The long URL to look up
+- `exactly_one` (optional): If false, returns all keywords for this URL (default: true)
+
+#### 11. delete_url
+
+Delete a short URL.
+*Requires the API Delete plugin to be installed.*
+
+**Parameters:**
+- `shorturl` (required): The short URL or keyword to delete
+
+#### 12. list_urls
+
+Get a list of URLs with sorting, pagination, and filtering options.
+*Requires the API List Extended plugin to be installed.*
+
+**Parameters:**
+- `sortby` (optional): Field to sort by (keyword, url, title, ip, timestamp, clicks) (default: timestamp)
+- `sortorder` (optional): Sort order (ASC or DESC) (default: DESC)
+- `offset` (optional): Pagination offset (default: 0)
+- `perpage` (optional): Number of results per page (default: 50)
+- `query` (optional): Optional search query for filtering by keyword
+- `fields` (optional): Fields to return (keyword, url, title, timestamp, ip, clicks) (default: all fields)
+
 ## Usage Examples
 
 Once configured, Claude will be able to use the YOURLS tools with prompts like:
+
+### Core Feature Examples
 
 - "Shorten this URL for me: https://example.com/very-long-url-that-needs-shortening"
 - "Create a short URL with the keyword 'docs' for https://example.com/documentation"
@@ -131,9 +197,25 @@ Once configured, Claude will be able to use the YOURLS tools with prompts like:
 - "Expand this short URL: https://yourdomain.com/abc"
 - "How many clicks does my short URL https://yourdomain.com/abc have?"
 - "Show me the statistics for my YOURLS instance"
+
+### Plugin-based Feature Examples
+
 - "Give me detailed analytics for shorturl 'abc' for January 2025"
 - "Show me the click statistics for bysha.pe/abc from 2025-01-01 to 2025-01-31"
 - "What was the daily traffic for my shortURL 'web' last month?"
+- "Check if this URL has already been shortened: https://example.com/page"
+- "Has someone already created a short URL for https://example.com/page?"
+- "Update the destination of the short URL 'docs' to point to https://example.com/new-documentation"
+- "Change where the keyword 'docs' points to"
+- "Rename the short URL 'docs' to 'documentation'"
+- "Change the keyword of my short URL from 'docs' to 'documentation'"
+- "What is the keyword for this long URL: https://example.com/page?"
+- "List all the short URLs for https://example.com/page"
+- "Delete the short URL 'docs'"
+- "Remove the keyword 'docs' from my YOURLS instance"
+- "Show me the most recent 10 short URLs in my YOURLS database"
+- "List all the short URLs sorted by number of clicks"
+- "Search for short URLs containing 'product'"
 
 ## Development
 

--- a/src/api.js
+++ b/src/api.js
@@ -242,4 +242,186 @@ export default class YourlsClient {
       throw error;
     }
   }
+  
+  /**
+   * Check if a URL has been shortened without creating a new short URL
+   * 
+   * @param {string} url - The URL to check
+   * @returns {Promise<object>} API response with information about whether the URL exists
+   */
+  async contractUrl(url) {
+    try {
+      return this.request('contract', { url });
+    } catch (error) {
+      // If the plugin isn't installed, we'll get an error about unknown action
+      if (error.response && 
+          error.response.data && 
+          (error.response.data.message === 'Unknown or missing action' ||
+           error.response.data.message?.includes('Unknown action'))) {
+        throw new Error('The contract action is not available. Please install the API Contract plugin.');
+      }
+      
+      // Otherwise, re-throw the original error
+      throw error;
+    }
+  }
+  
+  /**
+   * Update a short URL to point to a different destination URL
+   * 
+   * @param {string} shorturl - The short URL or keyword to update
+   * @param {string} url - The new destination URL
+   * @param {string} [title] - Optional new title ('keep' to keep existing, 'auto' to fetch from URL)
+   * @returns {Promise<object>} API response
+   */
+  async updateUrl(shorturl, url, title = null) {
+    const params = { shorturl, url };
+    
+    if (title) {
+      params.title = title;
+    }
+    
+    try {
+      return this.request('update', params);
+    } catch (error) {
+      // If the plugin isn't installed, we'll get an error about unknown action
+      if (error.response && 
+          error.response.data && 
+          (error.response.data.message === 'Unknown or missing action' ||
+           error.response.data.message?.includes('Unknown action'))) {
+        throw new Error('The update action is not available. Please install the API Edit URL plugin.');
+      }
+      
+      // Otherwise, re-throw the original error
+      throw error;
+    }
+  }
+  
+  /**
+   * Change the keyword of an existing short URL
+   * 
+   * @param {string} oldshorturl - The existing short URL or keyword
+   * @param {string} newshorturl - The new keyword to use
+   * @param {string} [url] - Optional URL (if not provided, will use the URL from oldshorturl)
+   * @param {string} [title] - Optional new title ('keep' to keep existing, 'auto' to fetch from URL)
+   * @returns {Promise<object>} API response
+   */
+  async changeKeyword(oldshorturl, newshorturl, url = null, title = null) {
+    const params = { 
+      oldshorturl,
+      newshorturl
+    };
+    
+    if (url) {
+      params.url = url;
+    }
+    
+    if (title) {
+      params.title = title;
+    }
+    
+    try {
+      return this.request('change_keyword', params);
+    } catch (error) {
+      // If the plugin isn't installed, we'll get an error about unknown action
+      if (error.response && 
+          error.response.data && 
+          (error.response.data.message === 'Unknown or missing action' ||
+           error.response.data.message?.includes('Unknown action'))) {
+        throw new Error('The change_keyword action is not available. Please install the API Edit URL plugin.');
+      }
+      
+      // Otherwise, re-throw the original error
+      throw error;
+    }
+  }
+  
+  /**
+   * Get the keyword(s) for a long URL
+   * 
+   * @param {string} url - The long URL to look up
+   * @param {boolean} [exactlyOne=true] - If false, returns all keywords for this URL
+   * @returns {Promise<object>} API response with keyword information
+   */
+  async getUrlKeyword(url, exactlyOne = true) {
+    const params = { url };
+    
+    if (!exactlyOne) {
+      params.exactly_one = 'false';
+    }
+    
+    try {
+      return this.request('geturl', params);
+    } catch (error) {
+      // If the plugin isn't installed, we'll get an error about unknown action
+      if (error.response && 
+          error.response.data && 
+          (error.response.data.message === 'Unknown or missing action' ||
+           error.response.data.message?.includes('Unknown action'))) {
+        throw new Error('The geturl action is not available. Please install the API Edit URL plugin.');
+      }
+      
+      // Otherwise, re-throw the original error
+      throw error;
+    }
+  }
+  
+  /**
+   * Delete a short URL
+   * 
+   * @param {string} shorturl - The short URL or keyword to delete
+   * @returns {Promise<object>} API response
+   */
+  async deleteUrl(shorturl) {
+    try {
+      return this.request('delete', { shorturl });
+    } catch (error) {
+      // If the plugin isn't installed, we'll get an error about unknown action
+      if (error.response && 
+          error.response.data && 
+          (error.response.data.message === 'Unknown or missing action' ||
+           error.response.data.message?.includes('Unknown action'))) {
+        throw new Error('The delete action is not available. Please install the API Delete plugin.');
+      }
+      
+      // Otherwise, re-throw the original error
+      throw error;
+    }
+  }
+  
+  /**
+   * Get a list of URLs with sorting, pagination, and filtering options
+   * 
+   * @param {object} options - List options
+   * @param {string} [options.sortby='timestamp'] - Field to sort by (keyword, url, title, ip, timestamp, clicks)
+   * @param {string} [options.sortorder='DESC'] - Sort order (ASC or DESC)
+   * @param {number} [options.offset=0] - Pagination offset
+   * @param {number} [options.perpage=50] - Number of results per page
+   * @param {string} [options.query=''] - Optional search query for filtering by keyword
+   * @param {string[]} [options.fields=['*']] - Fields to return (keyword, url, title, timestamp, ip, clicks)
+   * @returns {Promise<object>} API response with list of URLs
+   */
+  async listUrls({ sortby = 'timestamp', sortorder = 'DESC', offset = 0, perpage = 50, query = '', fields = ['*'] } = {}) {
+    try {
+      return this.request('list', { 
+        sortby, 
+        sortorder, 
+        offset, 
+        perpage, 
+        query,
+        fields
+      });
+    } catch (error) {
+      // If the plugin isn't installed, we'll get an error about unknown action
+      if (error.response && 
+          error.response.data && 
+          (error.response.data.message === 'Unknown or missing action' ||
+           error.response.data.message?.includes('Unknown action'))) {
+        throw new Error('The list action is not available. Please install the API List Extended plugin.');
+      }
+      
+      // Otherwise, re-throw the original error
+      throw error;
+    }
+  }
 }

--- a/src/tools/changeKeyword.js
+++ b/src/tools/changeKeyword.js
@@ -1,0 +1,77 @@
+/**
+ * YOURLS-MCP Tool: Change the keyword of an existing short URL
+ */
+import { z } from 'zod';
+
+/**
+ * Creates the change keyword tool
+ * 
+ * @param {object} yourlsClient - YOURLS API client instance
+ * @returns {object} MCP tool definition
+ */
+export default function createChangeKeywordTool(yourlsClient) {
+  return {
+    name: 'change_keyword',
+    description: 'Change the keyword of an existing short URL',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        oldshorturl: {
+          type: 'string',
+          description: 'The existing short URL or keyword'
+        },
+        newshorturl: {
+          type: 'string',
+          description: 'The new keyword to use'
+        },
+        url: {
+          type: 'string',
+          description: 'Optional URL (if not provided, will use the URL from oldshorturl)'
+        },
+        title: {
+          type: 'string',
+          description: 'Optional new title ("keep" to keep existing, "auto" to fetch from URL)'
+        }
+      },
+      required: ['oldshorturl', 'newshorturl']
+    },
+    execute: async ({ oldshorturl, newshorturl, url, title }) => {
+      try {
+        const result = await yourlsClient.changeKeyword(oldshorturl, newshorturl, url, title);
+        
+        if (result.message === 'success: updated') {
+          return {
+            content: [
+              {
+                type: 'text',
+                text: JSON.stringify({
+                  status: 'success',
+                  oldshorturl: oldshorturl,
+                  newshorturl: newshorturl,
+                  message: result.simple || 'Keyword changed successfully'
+                })
+              }
+            ]
+          };
+        } else {
+          throw new Error(result.message || 'Unknown error');
+        }
+      } catch (error) {
+        return {
+          content: [
+            {
+              type: 'text',
+              text: JSON.stringify({
+                status: 'error',
+                message: error.message,
+                oldshorturl: oldshorturl,
+                newshorturl: newshorturl
+              })
+            }
+          ],
+          isError: true
+        };
+      }
+    }
+  };
+}

--- a/src/tools/contractUrl.js
+++ b/src/tools/contractUrl.js
@@ -1,0 +1,64 @@
+/**
+ * YOURLS-MCP Tool: Check if a URL has been shortened
+ */
+import { z } from 'zod';
+
+/**
+ * Creates the contract URL tool
+ * 
+ * @param {object} yourlsClient - YOURLS API client instance
+ * @returns {object} MCP tool definition
+ */
+export default function createContractUrlTool(yourlsClient) {
+  return {
+    name: 'contract_url',
+    description: 'Check if a URL has already been shortened without creating a new short URL',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        url: {
+          type: 'string',
+          description: 'The URL to check if it has been shortened'
+        }
+      },
+      required: ['url']
+    },
+    execute: async ({ url }) => {
+      try {
+        const result = await yourlsClient.contractUrl(url);
+        
+        if (result.message === 'success') {
+          return {
+            content: [
+              {
+                type: 'text',
+                text: JSON.stringify({
+                  status: 'success',
+                  url: url,
+                  exists: result.url_exists,
+                  links: result.links || []
+                })
+              }
+            ]
+          };
+        } else {
+          throw new Error(result.message || 'Unknown error');
+        }
+      } catch (error) {
+        return {
+          content: [
+            {
+              type: 'text',
+              text: JSON.stringify({
+                status: 'error',
+                message: error.message,
+                url: url
+              })
+            }
+          ],
+          isError: true
+        };
+      }
+    }
+  };
+}

--- a/src/tools/deleteUrl.js
+++ b/src/tools/deleteUrl.js
@@ -1,0 +1,63 @@
+/**
+ * YOURLS-MCP Tool: Delete a short URL
+ */
+import { z } from 'zod';
+
+/**
+ * Creates the delete URL tool
+ * 
+ * @param {object} yourlsClient - YOURLS API client instance
+ * @returns {object} MCP tool definition
+ */
+export default function createDeleteUrlTool(yourlsClient) {
+  return {
+    name: 'delete_url',
+    description: 'Delete a short URL',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        shorturl: {
+          type: 'string',
+          description: 'The short URL or keyword to delete'
+        }
+      },
+      required: ['shorturl']
+    },
+    execute: async ({ shorturl }) => {
+      try {
+        const result = await yourlsClient.deleteUrl(shorturl);
+        
+        if (result.message === 'success: deleted') {
+          return {
+            content: [
+              {
+                type: 'text',
+                text: JSON.stringify({
+                  status: 'success',
+                  shorturl: shorturl,
+                  message: result.simple || 'Short URL deleted successfully'
+                })
+              }
+            ]
+          };
+        } else {
+          throw new Error(result.message || 'Unknown error');
+        }
+      } catch (error) {
+        return {
+          content: [
+            {
+              type: 'text',
+              text: JSON.stringify({
+                status: 'error',
+                message: error.message,
+                shorturl: shorturl
+              })
+            }
+          ],
+          isError: true
+        };
+      }
+    }
+  };
+}

--- a/src/tools/getUrlKeyword.js
+++ b/src/tools/getUrlKeyword.js
@@ -29,6 +29,11 @@ export default function createGetUrlKeywordTool(yourlsClient) {
     },
     execute: async ({ url, exactly_one = true }) => {
       try {
+        // Normalize boolean parameter if it's passed as a string
+        if (typeof exactly_one === 'string') {
+          exactly_one = exactly_one.toLowerCase() === 'true';
+        }
+        
         const result = await yourlsClient.getUrlKeyword(url, exactly_one);
         
         if (result.message === 'success: found') {

--- a/src/tools/getUrlKeyword.js
+++ b/src/tools/getUrlKeyword.js
@@ -1,0 +1,68 @@
+/**
+ * YOURLS-MCP Tool: Get the keyword(s) for a long URL
+ */
+import { z } from 'zod';
+
+/**
+ * Creates the get URL keyword tool
+ * 
+ * @param {object} yourlsClient - YOURLS API client instance
+ * @returns {object} MCP tool definition
+ */
+export default function createGetUrlKeywordTool(yourlsClient) {
+  return {
+    name: 'get_url_keyword',
+    description: 'Get the keyword(s) for a long URL',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        url: {
+          type: 'string',
+          description: 'The long URL to look up'
+        },
+        exactly_one: {
+          type: 'boolean',
+          description: 'If false, returns all keywords for this URL (default: true)'
+        }
+      },
+      required: ['url']
+    },
+    execute: async ({ url, exactly_one = true }) => {
+      try {
+        const result = await yourlsClient.getUrlKeyword(url, exactly_one);
+        
+        if (result.message === 'success: found') {
+          return {
+            content: [
+              {
+                type: 'text',
+                text: JSON.stringify({
+                  status: 'success',
+                  url: url,
+                  keyword: result.keyword,
+                  message: result.simple || 'Keywords found'
+                })
+              }
+            ]
+          };
+        } else {
+          throw new Error(result.message || 'Unknown error');
+        }
+      } catch (error) {
+        return {
+          content: [
+            {
+              type: 'text',
+              text: JSON.stringify({
+                status: 'error',
+                message: error.message,
+                url: url
+              })
+            }
+          ],
+          isError: true
+        };
+      }
+    }
+  };
+}

--- a/src/tools/index.js
+++ b/src/tools/index.js
@@ -6,6 +6,12 @@ import createExpandUrlTool from './expandUrl.js';
 import createUrlStatsTool from './urlStats.js';
 import createDbStatsTool from './dbStats.js';
 import createShortUrlAnalyticsTool from './shortUrlAnalytics.js';
+import createContractUrlTool from './contractUrl.js';
+import createUpdateUrlTool from './updateUrl.js';
+import createChangeKeywordTool from './changeKeyword.js';
+import createGetUrlKeywordTool from './getUrlKeyword.js';
+import createDeleteUrlTool from './deleteUrl.js';
+import createListUrlsTool from './listUrls.js';
 
 /**
  * Register all tools with the MCP server
@@ -14,15 +20,33 @@ import createShortUrlAnalyticsTool from './shortUrlAnalytics.js';
  * @param {object} yourlsClient - YOURLS API client
  */
 export function registerTools(server, yourlsClient) {
+  // Core YOURLS API tools
   const shortenUrlTool = createShortenUrlTool(yourlsClient);
   const expandUrlTool = createExpandUrlTool(yourlsClient);
   const urlStatsTool = createUrlStatsTool(yourlsClient);
   const dbStatsTool = createDbStatsTool(yourlsClient);
-  const shortUrlAnalyticsTool = createShortUrlAnalyticsTool(yourlsClient);
   
+  // Plugin-based API tools
+  const shortUrlAnalyticsTool = createShortUrlAnalyticsTool(yourlsClient);
+  const contractUrlTool = createContractUrlTool(yourlsClient);
+  const updateUrlTool = createUpdateUrlTool(yourlsClient);
+  const changeKeywordTool = createChangeKeywordTool(yourlsClient);
+  const getUrlKeywordTool = createGetUrlKeywordTool(yourlsClient);
+  const deleteUrlTool = createDeleteUrlTool(yourlsClient);
+  const listUrlsTool = createListUrlsTool(yourlsClient);
+  
+  // Register core tools
   server.addTool(shortenUrlTool);
   server.addTool(expandUrlTool);
   server.addTool(urlStatsTool);
   server.addTool(dbStatsTool);
+  
+  // Register plugin-based tools
   server.addTool(shortUrlAnalyticsTool);
+  server.addTool(contractUrlTool);
+  server.addTool(updateUrlTool);
+  server.addTool(changeKeywordTool);
+  server.addTool(getUrlKeywordTool);
+  server.addTool(deleteUrlTool);
+  server.addTool(listUrlsTool);
 }

--- a/src/tools/listUrls.js
+++ b/src/tools/listUrls.js
@@ -1,0 +1,93 @@
+/**
+ * YOURLS-MCP Tool: Get a list of URLs with sorting, pagination, and filtering options
+ */
+import { z } from 'zod';
+
+/**
+ * Creates the list URLs tool
+ * 
+ * @param {object} yourlsClient - YOURLS API client instance
+ * @returns {object} MCP tool definition
+ */
+export default function createListUrlsTool(yourlsClient) {
+  return {
+    name: 'list_urls',
+    description: 'Get a list of URLs with sorting, pagination, and filtering options',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        sortby: {
+          type: 'string',
+          description: 'Field to sort by (keyword, url, title, ip, timestamp, clicks)'
+        },
+        sortorder: {
+          type: 'string',
+          description: 'Sort order (ASC or DESC)'
+        },
+        offset: {
+          type: 'number',
+          description: 'Pagination offset'
+        },
+        perpage: {
+          type: 'number',
+          description: 'Number of results per page'
+        },
+        query: {
+          type: 'string',
+          description: 'Optional search query for filtering by keyword'
+        },
+        fields: {
+          type: 'array',
+          items: {
+            type: 'string'
+          },
+          description: 'Fields to return (keyword, url, title, timestamp, ip, clicks)'
+        }
+      }
+    },
+    execute: async ({ sortby, sortorder, offset, perpage, query, fields }) => {
+      try {
+        const result = await yourlsClient.listUrls({
+          sortby,
+          sortorder,
+          offset,
+          perpage,
+          query,
+          fields
+        });
+        
+        if (result.message === 'success') {
+          return {
+            content: [
+              {
+                type: 'text',
+                text: JSON.stringify({
+                  status: 'success',
+                  total: result.total,
+                  offset: result.offset,
+                  perpage: result.perpage,
+                  results: result.result || []
+                })
+              }
+            ]
+          };
+        } else {
+          throw new Error(result.message || 'Unknown error');
+        }
+      } catch (error) {
+        return {
+          content: [
+            {
+              type: 'text',
+              text: JSON.stringify({
+                status: 'error',
+                message: error.message
+              })
+            }
+          ],
+          isError: true
+        };
+      }
+    }
+  };
+}

--- a/src/tools/listUrls.js
+++ b/src/tools/listUrls.js
@@ -47,13 +47,43 @@ export default function createListUrlsTool(yourlsClient) {
     },
     execute: async ({ sortby, sortorder, offset, perpage, query, fields }) => {
       try {
+        // Validate sortby
+        const validSortFields = ['keyword', 'url', 'title', 'ip', 'timestamp', 'clicks'];
+        if (sortby && !validSortFields.includes(sortby)) {
+          throw new Error(`Invalid sortby value. Must be one of: ${validSortFields.join(', ')}`);
+        }
+        
+        // Validate sortorder
+        if (sortorder && !['ASC', 'DESC', 'asc', 'desc'].includes(sortorder)) {
+          throw new Error('Invalid sortorder value. Must be ASC or DESC');
+        }
+        
+        // Validate numeric parameters
+        if (offset !== undefined && (isNaN(Number(offset)) || Number(offset) < 0)) {
+          throw new Error('Offset must be a non-negative number');
+        }
+        
+        if (perpage !== undefined && (isNaN(Number(perpage)) || Number(perpage) <= 0)) {
+          throw new Error('Perpage must be a positive number');
+        }
+        
+        // Normalize fields if needed
+        let normalizedFields = fields;
+        if (typeof fields === 'string') {
+          try {
+            normalizedFields = JSON.parse(fields);
+          } catch (e) {
+            normalizedFields = fields.split(',').map(f => f.trim());
+          }
+        }
+        
         const result = await yourlsClient.listUrls({
           sortby,
           sortorder,
-          offset,
-          perpage,
+          offset: offset !== undefined ? Number(offset) : undefined,
+          perpage: perpage !== undefined ? Number(perpage) : undefined,
           query,
-          fields
+          fields: normalizedFields
         });
         
         if (result.message === 'success') {

--- a/src/tools/updateUrl.js
+++ b/src/tools/updateUrl.js
@@ -1,0 +1,73 @@
+/**
+ * YOURLS-MCP Tool: Update a short URL to point to a different destination
+ */
+import { z } from 'zod';
+
+/**
+ * Creates the update URL tool
+ * 
+ * @param {object} yourlsClient - YOURLS API client instance
+ * @returns {object} MCP tool definition
+ */
+export default function createUpdateUrlTool(yourlsClient) {
+  return {
+    name: 'update_url',
+    description: 'Update an existing short URL to point to a different destination URL',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        shorturl: {
+          type: 'string',
+          description: 'The short URL or keyword to update'
+        },
+        url: {
+          type: 'string',
+          description: 'The new destination URL'
+        },
+        title: {
+          type: 'string',
+          description: 'Optional new title ("keep" to keep existing, "auto" to fetch from URL)'
+        }
+      },
+      required: ['shorturl', 'url']
+    },
+    execute: async ({ shorturl, url, title }) => {
+      try {
+        const result = await yourlsClient.updateUrl(shorturl, url, title);
+        
+        if (result.message === 'success: updated') {
+          return {
+            content: [
+              {
+                type: 'text',
+                text: JSON.stringify({
+                  status: 'success',
+                  shorturl: shorturl,
+                  url: url,
+                  message: result.simple || 'Short URL updated successfully'
+                })
+              }
+            ]
+          };
+        } else {
+          throw new Error(result.message || 'Unknown error');
+        }
+      } catch (error) {
+        return {
+          content: [
+            {
+              type: 'text',
+              text: JSON.stringify({
+                status: 'error',
+                message: error.message,
+                shorturl: shorturl,
+                url: url
+              })
+            }
+          ],
+          isError: true
+        };
+      }
+    }
+  };
+}


### PR DESCRIPTION
## Summary
- Implements API client methods and MCP tools for YOURLS API plugins
- Adds comprehensive documentation for all new tools
- Includes graceful fallbacks when plugins aren't installed
- Organizes tools into core and plugin-based sections

## Related Issue
Closes #6

This PR adds support for the following YOURLS API plugins:
- API Contract: Check if a URL has been shortened without creating a new short URL
- API Edit URL: Update URL destinations, change keywords, and look up URLs
- API Delete: Delete short URLs
- API List Extended: List URLs with sorting, pagination, and filtering

Each plugin now has dedicated API client methods with proper error handling and corresponding MCP tools. The README.md has been updated to document all new capabilities with usage examples.